### PR TITLE
object rest spread now well supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ $ npm install --save-dev babel-preset-es2015-node6
 Read ["Configuring Babel 6" article](http://www.2ality.com/2015/11/configuring-babel6.html)
 for more information about babel@6 configuration.
 
-__*NOTE*__ If you're using `object-rest` feature of `stage-2`, use `es2015-node6/object-rest` instead of `es2015-node6` (It's added back `destructuring`, `parameters`), or down to `^0.1.4`. Waiting [#2](https://github.com/jhen0409/babel-preset-es2015-node6/issues/2), [T7086](https://phabricator.babeljs.io/T7086) fix.
-
 ### Via `.babelrc` (recommended)
 
 **.babelrc**


### PR DESCRIPTION
https://github.com/babel/babel/issues/4074 has been handled in `babel-plugin-transform-object-rest-spread`. As of https://github.com/babel/babel/releases/tag/v6.19.0 `babel-plugin-transform-object-rest-spread` now works well with this preset.

/cc @peggyrayzis